### PR TITLE
fix: allow disabling summary per post with is_summary: false

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ hexo.extend.filter.register('before_post_render', async function (data) {
     }
 
     return await limit(async () => {
-        if (!config.enable && !data.is_summary) {
+        if (!config.enable || data.is_summary === false) {
             if (logLevel >= LOG_LEVELS.VERBOSE) {
                 console.info(`[Hexo-AI-Summary-LiuShen] 文章 ${data.title} 被标记为不进行摘要，跳过`)
             }


### PR DESCRIPTION
## 问题
目前如果在全局配置中``aisummary.enable = true``，文章 **front-matter** 里的 ``is_summary: false`` 无法生效。
原因是源码使用了：
```js
if (!config.enable && !data.is_summary)
```
逻辑要求“全局关闭 **并且** 文章关闭”才跳过摘要，导致单篇禁用失效。

## 解决
把``&&``改为``||``，修改为：
```js
if (!config.enable || data.is_summary === false) {
```

## 效果
- 全局开启 + is_summary: false → 不生成摘要 ✅
- 全局关闭 + is_summary: true → 生成摘要 ✅

## Summary by Sourcery

Bug Fixes:
- Change disable condition to use logical OR so that `is_summary: false` in front-matter skips summary even when summaries are globally enabled.